### PR TITLE
Feature/te 285 lazy loading

### DIFF
--- a/core/org.testeditor.core/src/main/java/org/testeditor/core/model/teststructure/TestCompositeStructure.java
+++ b/core/org.testeditor.core/src/main/java/org/testeditor/core/model/teststructure/TestCompositeStructure.java
@@ -44,12 +44,21 @@ public abstract class TestCompositeStructure extends TestStructure {
 	 * @return test children
 	 */
 	public List<TestStructure> getTestChildren() {
-		boolean areAllChildsOfTheBackendLoaded = childCountInBackend != testChildren.size() && lazyLoader != null;
-		if (areAllChildsOfTheBackendLoaded) {
-			childCountInBackend = 0;
-			lazyLoader.run();
+		boolean areNotAllChildsOfTheBackendLoaded = childCountInBackend != testChildren.size() && lazyLoader != null;
+		if (areNotAllChildsOfTheBackendLoaded) {
+			loadChildrenLazy();
 		}
 		return testChildren;
+	}
+
+	/**
+	 * Loads children lazy. It removes all existing references and loads it
+	 * clean with the lazy loader.
+	 */
+	protected void loadChildrenLazy() {
+		testChildren = new ArrayList<TestStructure>();
+		childCountInBackend = testChildren.size();
+		lazyLoader.run();
 	}
 
 	/**

--- a/core/org.testeditor.core/src/main/java/org/testeditor/core/model/teststructure/TestCompositeStructure.java
+++ b/core/org.testeditor.core/src/main/java/org/testeditor/core/model/teststructure/TestCompositeStructure.java
@@ -46,6 +46,7 @@ public abstract class TestCompositeStructure extends TestStructure {
 	public List<TestStructure> getTestChildren() {
 		boolean areAllChildsOfTheBackendLoaded = childCountInBackend != testChildren.size() && lazyLoader != null;
 		if (areAllChildsOfTheBackendLoaded) {
+			childCountInBackend = 0;
 			lazyLoader.run();
 		}
 		return testChildren;

--- a/core/org.testeditor.core/src/main/java/org/testeditor/core/model/teststructure/TestCompositeStructure.java
+++ b/core/org.testeditor.core/src/main/java/org/testeditor/core/model/teststructure/TestCompositeStructure.java
@@ -44,7 +44,7 @@ public abstract class TestCompositeStructure extends TestStructure {
 	 * @return test children
 	 */
 	public List<TestStructure> getTestChildren() {
-		boolean areNotAllChildsOfTheBackendLoaded = childCountInBackend != testChildren.size() && lazyLoader != null;
+		boolean areNotAllChildsOfTheBackendLoaded = childCountInBackend != testChildren.size();
 		if (areNotAllChildsOfTheBackendLoaded) {
 			loadChildrenLazy();
 		}
@@ -56,7 +56,10 @@ public abstract class TestCompositeStructure extends TestStructure {
 	 * clean with the lazy loader.
 	 */
 	protected void loadChildrenLazy() {
-		testChildren = new ArrayList<TestStructure>();
+		if (lazyLoader == null) {
+			throw new RuntimeException("No Lazy Loader set for: " + toString());
+		}
+		testChildren.clear();
 		childCountInBackend = testChildren.size();
 		lazyLoader.run();
 	}

--- a/core/org.testeditor.core/src/test/java/org/testeditor/core/model/teststructure/TestCompositeStructureTest.java
+++ b/core/org.testeditor.core/src/test/java/org/testeditor/core/model/teststructure/TestCompositeStructureTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -161,6 +162,28 @@ public class TestCompositeStructureTest {
 		out.removeChild(testCase);
 		assertEquals("Don't remove Object that is not in list", 3, out.getTestChildren().size());
 		assertFalse("Lazy Loader is not a second time executed.", Boolean.parseBoolean(monitor.get("seen")));
+	}
+
+	/**
+	 * Tests the lazy loading conditions on -1 init.
+	 */
+	@Test
+	public void testLoadChildrenLazy() {
+		TestCompositeStructure compositeStructure = getOUT();
+		final ArrayList<Date> lazyCounter = new ArrayList<Date>();
+		compositeStructure.setChildCountInBackend(-1);
+		compositeStructure.setLazyLoader(new Runnable() {
+
+			@Override
+			public void run() {
+				lazyCounter.add(new Date());
+			}
+		});
+		assertEquals(0, lazyCounter.size());
+		compositeStructure.loadChildrenLazy();
+		assertEquals(1, lazyCounter.size());
+		assertTrue(compositeStructure.getTestChildren().isEmpty());
+		assertEquals(1, lazyCounter.size());
 	}
 
 	/**


### PR DESCRIPTION
Fixing problem with lazy loafding in test projects which have -1 as init value. 
on lazy loading, they started with -1 which avoids the detection of full loaded object graph. This is fixed with correction the value before the lazy loader runs.
