### PR TITLE
TE-289 Avoid ui freece on update operation

### DIFF
--- a/core/org.testeditor.core/log4j.xml
+++ b/core/org.testeditor.core/log4j.xml
@@ -23,7 +23,7 @@
 	<!-- alle Logs aus dem TestEditor werden geloggt -->
 	<appender class="org.apache.log4j.RollingFileAppender" name="testeditor">
 		<param name="file"
-			value="D:/Development/TestEditor/TestEditor_26092013/.testeditor/.metadata/logs/testeditor.log" />
+			value="target/.testeditor/.metadata/logs/testeditor.log" />
 		<param name="append" value="true" />
 		<param name="encoding" value="UTF-8" />
 		<param name="MaxFileSize" value="5000KB" />

--- a/ui/org.testeditor.ui/src/main/java/org/testeditor/ui/handlers/teamshare/AbstractUpdateOrApproveHandler.java
+++ b/ui/org.testeditor.ui/src/main/java/org/testeditor/ui/handlers/teamshare/AbstractUpdateOrApproveHandler.java
@@ -90,7 +90,7 @@ public abstract class AbstractUpdateOrApproveHandler {
 		final Shell activeShell = Display.getCurrent().getActiveShell();
 		final ProgressMonitorDialog dialog = new ProgressMonitorDialog(activeShell);
 		try {
-			dialog.run(false, false, new IRunnableWithProgress() {
+			dialog.run(true, false, new IRunnableWithProgress() {
 
 				@Override
 				public void run(final IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
@@ -128,7 +128,7 @@ public abstract class AbstractUpdateOrApproveHandler {
 						MessageDialog.openError(activeShell, translationService.translate("%error"), e.getMessage());
 						LOGGER.error(e, e);
 					}
-
+					monitor.done();
 				}
 			});
 


### PR DESCRIPTION
- fork for progress dialog and close the dialog
- remove hard coded path from log4j config

Task-Url: https://testeditor.atlassian.net/browse/TE-289
